### PR TITLE
Expose script and sha, provide method to ensure script is loaded

### DIFF
--- a/lib/em-hiredis/client.rb
+++ b/lib/em-hiredis/client.rb
@@ -33,6 +33,12 @@ module EventMachine::Hiredis
       self.send(:define_method, name.to_sym) { |keys, args=[]|
         eval_script(lua, sha, keys, args)
       }
+      self.send(:define_method, "#{name}_script".to_sym) {
+        lua
+      }
+      self.send(:define_method, "#{name}_sha".to_sym) {
+        sha
+      }
     end
 
     def register_script(name, lua)


### PR DESCRIPTION
When running scripts in a `multi` context, em-hiredis is not able to detect `evalsha` failure and resubmit using the entire script text, because the other commands have already been processed and the script failed. To re-run the script after the `exec` would seriously break the semantics.

Therefore we provide `ensure_script`, which can be used to ensure that a script is loaded by sha before attempting to use it in a `multi` block.