### PR TITLE
Only unsubscribe a proc if there is an existing channel subscription

### DIFF
--- a/lib/em-hiredis/pubsub_client.rb
+++ b/lib/em-hiredis/pubsub_client.rb
@@ -248,11 +248,13 @@ module EventMachine::Hiredis
     end
 
     def unsubscribe_proc_impl(type, subscriptions, channel, proc)
-      removed = subscriptions[channel].delete(proc)
+      if subscriptions.include?(channel)
+        subscriptions[channel].delete(proc)
 
-      # Kill the redis subscription if that was the last callback
-      if removed && subscriptions[channel].empty?
-        unsubscribe_impl(type, subscriptions, channel)
+        # Kill the redis subscription if that was the last callback
+        if subscriptions[channel].empty?
+          unsubscribe_impl(type, subscriptions, channel)
+        end
       end
 
       return nil

--- a/spec/pubsub_client_conn_spec.rb
+++ b/spec/pubsub_client_conn_spec.rb
@@ -36,6 +36,15 @@ describe EM::Hiredis::PubsubClient do
       end
     end
 
+    it "should not error when trying to unsubscribe a proc from a channel subscription that does not exist" do
+      mock_connections(1) do |client, (connection)|
+        client.connect
+        connection.connection_completed
+
+        lambda { client.unsubscribe_proc('channel', Proc.new { |m| fail }) }.should_not raise_error
+      end
+    end
+
     it "should allow selective unsubscription" do
       mock_connections(1) do |client, (connection)|
         client.connect


### PR DESCRIPTION
If there is no channel in the subscriptions object and we try to unsubscribe a proc from it, it will throw an error.

https://beta.getsentry.com/pusher/server/group/85505267/

This is a work around fix, but I am not sure how the pub sub client does not have the channel in the subscriptions object when the message bus has a subscription for the same channel name. I can investigate further or I might be missing something thats obvious.

@mdpye