### PR TITLE
Redis sentinel

### DIFF
--- a/lib/em-hiredis/connection_manager.rb
+++ b/lib/em-hiredis/connection_manager.rb
@@ -154,10 +154,6 @@ module EventMachine::Hiredis
       # state when we emit :disconnected and :reconnected, so we should only
       # proceed here if our state has not been touched.
       return unless @sm.state == :disconnected
-
-      # if @reconnect_attempt > 3
-        # @sm.update_state(:failed)
-      # else
         @reconnect_attempt += 1
         if delay_reconnect
           @reconnect_timer = @em.add_timer(EventMachine::Hiredis.reconnect_timeout) {
@@ -166,7 +162,6 @@ module EventMachine::Hiredis
         else
           @sm.update_state(:connecting)
         end
-      # end
     end
   end
 end

--- a/lib/em-hiredis/connection_manager.rb
+++ b/lib/em-hiredis/connection_manager.rb
@@ -155,9 +155,9 @@ module EventMachine::Hiredis
       # proceed here if our state has not been touched.
       return unless @sm.state == :disconnected
 
-      if @reconnect_attempt > 3
-        @sm.update_state(:failed)
-      else
+      # if @reconnect_attempt > 3
+        # @sm.update_state(:failed)
+      # else
         @reconnect_attempt += 1
         if delay_reconnect
           @reconnect_timer = @em.add_timer(EventMachine::Hiredis.reconnect_timeout) {
@@ -166,7 +166,7 @@ module EventMachine::Hiredis
         else
           @sm.update_state(:connecting)
         end
-      end
+      # end
     end
   end
 end

--- a/lib/em-hiredis/pubsub_client.rb
+++ b/lib/em-hiredis/pubsub_client.rb
@@ -40,7 +40,8 @@ module EventMachine::Hiredis
         uri,
         inactivity_trigger_secs = nil,
         inactivity_response_timeout = nil,
-        em = EventMachine)
+        em = EventMachine,
+        options = {})
 
       @em = em
       configure(uri)
@@ -55,7 +56,7 @@ module EventMachine::Hiredis
       @subscriptions = {}
       @psubscriptions = {}
 
-      @connection_manager = ConnectionManager.new(method(:factory_connection), em)
+      @connection_manager = ConnectionManager.new(method(:factory_connection), em, options)
 
       @connection_manager.on(:connected) {
         EM::Hiredis.logger.info("#{@name} - Connected")

--- a/lib/em-hiredis/pubsub_client.rb
+++ b/lib/em-hiredis/pubsub_client.rb
@@ -36,12 +36,15 @@ module EventMachine::Hiredis
     # inactivity_response_timeout:
     #   the number of seconds after a ping at which to terminate the connection
     #   if there is still no activity
+    # reconnect_attempts:
+    #   the number of how many reconnect attempts it should complete
+    #   before declaring a connection as failed.
     def initialize(
         uri,
         inactivity_trigger_secs = nil,
         inactivity_response_timeout = nil,
         em = EventMachine,
-        options = {})
+        reconnect_attempts = nil)
 
       @em = em
       configure(uri)
@@ -56,7 +59,7 @@ module EventMachine::Hiredis
       @subscriptions = {}
       @psubscriptions = {}
 
-      @connection_manager = ConnectionManager.new(method(:factory_connection), em, options)
+      @connection_manager = ConnectionManager.new(method(:factory_connection), em, reconnect_attempts)
 
       @connection_manager.on(:connected) {
         EM::Hiredis.logger.info("#{@name} - Connected")

--- a/lib/em-hiredis/redis_client.rb
+++ b/lib/em-hiredis/redis_client.rb
@@ -22,12 +22,15 @@ module EventMachine::Hiredis
     # inactivity_response_timeout:
     #   the number of seconds after a ping at which to terminate the connection
     #   if there is still no activity
+    # reconnect_attempts:
+    #   the number of how many reconnect attempts it should complete
+    #   before declaring a connection as failed.
     def initialize(
         uri,
         inactivity_trigger_secs = nil,
         inactivity_response_timeout = nil,
         em = EventMachine,
-        options = {})
+        reconnect_attempts = nil)
 
       @em = em
       configure(uri)
@@ -38,7 +41,7 @@ module EventMachine::Hiredis
       # Commands received while we are not initialized, to be sent once we are
       @command_queue = []
 
-      @connection_manager = ConnectionManager.new(method(:factory_connection), em, options)
+      @connection_manager = ConnectionManager.new(method(:factory_connection), em, reconnect_attempts)
 
       @connection_manager.on(:connected) {
         EM::Hiredis.logger.info("#{@name} - Connected")

--- a/lib/em-hiredis/redis_client.rb
+++ b/lib/em-hiredis/redis_client.rb
@@ -26,7 +26,8 @@ module EventMachine::Hiredis
         uri,
         inactivity_trigger_secs = nil,
         inactivity_response_timeout = nil,
-        em = EventMachine)
+        em = EventMachine,
+        options = {})
 
       @em = em
       configure(uri)
@@ -37,7 +38,7 @@ module EventMachine::Hiredis
       # Commands received while we are not initialized, to be sent once we are
       @command_queue = []
 
-      @connection_manager = ConnectionManager.new(method(:factory_connection), em)
+      @connection_manager = ConnectionManager.new(method(:factory_connection), em, options)
 
       @connection_manager.on(:connected) {
         EM::Hiredis.logger.info("#{@name} - Connected")


### PR DESCRIPTION
As we're moving to Redis Sentinel we want the library to handle the infinite reconnect. In the future `pusher-server` will not connect to `redis` directly anymore, the connection will go through `redis-proxy`. Therefore we need `pusher-server` trying to reconnect the proxy infinitely while redises handling the failover.

Current behavior is the following: if the connection to Redis is lost, try to reconnect 3 times. In case of failure - emit `:failed`. In case of infinite reconnect we will never emit `:failed`, we will only use `:disconnected`, `:connected`, `:reconnect_failed` states.