### PR TITLE
Ping init

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,6 @@ This configures a `PING` command to be sent if 5 seconds elapse without receivin
 
 This configuration is per client, you may choose different value for clients with different expected traffic patterns, or activate it on some and not at all on others.
 
-### PING and Pubsub
-
-Because the Redis Pubsub protocol limits the set of valid commands on a connection once it is in "Pubsub" mode, `PING` is not supported in this case (though it may be in future, see https://github.com/antirez/redis/issues/420). In order to create some valid request-response traffic on the connection, a Pubsub connection will issue `SUBSCRIBE "__em-hiredis-ping"`, followed by a corresponding `UNSUBSCRIBE` immediately on success of the subscribe.
-While less than ideal, this is the case where an application layer inactivity check is most valuable, and so the trade off is reasonable until `PING` is supported correctly on Pubsub connections.
-
 ### Close to the metal
 
 Basically just bind to `:message` and `:pmessage` events:

--- a/lib/em-hiredis/pubsub_client.rb
+++ b/lib/em-hiredis/pubsub_client.rb
@@ -26,6 +26,7 @@ module EventMachine::Hiredis
     include EventMachine::Deferrable
 
     RESUBSCRIBE_BATCH_SIZE = 1000
+    DEFAULT_RESPONSE_TIMEOUT = 2 # seconds
 
     attr_reader :host, :port, :password
 
@@ -49,7 +50,8 @@ module EventMachine::Hiredis
       configure(uri)
 
       @inactivity_trigger_secs = inactivity_trigger_secs
-      @inactivity_response_timeout = inactivity_response_timeout
+
+      @inactivity_response_timeout = inactivity_response_timeout || DEFAULT_RESPONSE_TIMEOUT
 
       # Subscribed channels and patterns to their callbacks
       # nil is a valid "callback", required because even if the user is using
@@ -94,7 +96,6 @@ module EventMachine::Hiredis
     # Commands may be issued before or during connection, they will be queued
     # and submitted to the server once the connection is active.
     def connect
-      @inactivity_response_timeout = 2 if @inactivity_response_timeout.nil?
       @connection_manager.connect
       return self
     end

--- a/lib/em-hiredis/pubsub_client.rb
+++ b/lib/em-hiredis/pubsub_client.rb
@@ -94,6 +94,7 @@ module EventMachine::Hiredis
     # Commands may be issued before or during connection, they will be queued
     # and submitted to the server once the connection is active.
     def connect
+      @inactivity_response_timeout = 2 if @inactivity_response_timeout.nil?
       @connection_manager.connect
       return self
     end

--- a/lib/em-hiredis/pubsub_client.rb
+++ b/lib/em-hiredis/pubsub_client.rb
@@ -184,7 +184,7 @@ module EventMachine::Hiredis
 
         connection.on(:connected) {
           maybe_auth(connection).callback {
-
+            connection.ping_with_pubsub
             connection.on(:message, &method(:message_callbacks))
             connection.on(:pmessage, &method(:pmessage_callbacks))
 

--- a/lib/em-hiredis/pubsub_connection.rb
+++ b/lib/em-hiredis/pubsub_connection.rb
@@ -5,8 +5,6 @@ module EventMachine::Hiredis
     PUBSUB_COMMANDS = %w{ping subscribe unsubscribe psubscribe punsubscribe}.freeze
     PUBSUB_MESSAGES = (PUBSUB_COMMANDS + %w{message pmessage pong}).freeze
 
-    PING_CHANNEL = '__em-hiredis-ping'
-
     def initialize(inactivity_trigger_secs = nil,
                    inactivity_response_timeout = 2,
                    name = 'unnamed connection')

--- a/lib/em-hiredis/pubsub_connection.rb
+++ b/lib/em-hiredis/pubsub_connection.rb
@@ -101,6 +101,8 @@ module EventMachine::Hiredis
     end
 
     def handle_response(reply)
+      # In a password-protected Redis server it starts accepting commands only after auth succeeds.
+      # Therefore it is not possible for ping_df to complete before auth_df
       if @auth_df
         # If we're awaiting a response to auth, we will not have sent any other commands
         if reply.kind_of?(RuntimeError)
@@ -131,3 +133,4 @@ module EventMachine::Hiredis
     end
   end
 end
+

--- a/lib/em-hiredis/redis_client.rb
+++ b/lib/em-hiredis/redis_client.rb
@@ -13,6 +13,8 @@ module EventMachine::Hiredis
     include EventEmitter
     include EventMachine::Deferrable
 
+    DEFAULT_RESPONSE_TIMEOUT = 2 # seconds
+    
     attr_reader :host, :port, :password, :db
 
     # uri:
@@ -36,7 +38,7 @@ module EventMachine::Hiredis
       configure(uri)
 
       @inactivity_trigger_secs = inactivity_trigger_secs
-      @inactivity_response_timeout = inactivity_response_timeout
+      @inactivity_response_timeout = inactivity_response_timeout || DEFAULT_RESPONSE_TIMEOUT
 
       # Commands received while we are not initialized, to be sent once we are
       @command_queue = []
@@ -81,7 +83,6 @@ module EventMachine::Hiredis
     # Commands may be issued before or during connection, they will be queued
     # and submitted to the server once the connection is active.
     def connect
-      @inactivity_response_timeout = 2 if @inactivity_response_timeout.nil?
       @connection_manager.connect
       return self
     end

--- a/lib/em-hiredis/redis_client.rb
+++ b/lib/em-hiredis/redis_client.rb
@@ -313,7 +313,7 @@ module EventMachine::Hiredis
 
         connection.on(:connected) {
           maybe_auth(connection).callback {
-            connection.ping.timeout(2).callback {
+            connection.ping.timeout(@inactivity_response_timeout).callback {
               maybe_select(connection).callback {
                 @command_queue.each { |command_df, command, args|
                   connection.send_command(command_df, command, args)

--- a/lib/em-hiredis/redis_client.rb
+++ b/lib/em-hiredis/redis_client.rb
@@ -81,6 +81,7 @@ module EventMachine::Hiredis
     # Commands may be issued before or during connection, they will be queued
     # and submitted to the server once the connection is active.
     def connect
+      @inactivity_response_timeout = 2 if @inactivity_response_timeout.nil?
       @connection_manager.connect
       return self
     end

--- a/lib/em-hiredis/redis_client.rb
+++ b/lib/em-hiredis/redis_client.rb
@@ -313,7 +313,7 @@ module EventMachine::Hiredis
 
         connection.on(:connected) {
           maybe_auth(connection).callback {
-            connection.ping.callback {
+            connection.ping.timeout(2).callback {
               maybe_select(connection).callback {
                 @command_queue.each { |command_df, command, args|
                   connection.send_command(command_df, command, args)

--- a/lib/em-hiredis/redis_connection.rb
+++ b/lib/em-hiredis/redis_connection.rb
@@ -17,7 +17,7 @@ module EventMachine::Hiredis
       @inactivity_checker = InactivityChecker.new(inactivity_trigger_secs, inactivity_response_timeout)
       @inactivity_checker.on(:activity_timeout) {
         EM::Hiredis.logger.debug("#{@name} - Sending ping")
-        send_command(EM::DefaultDeferrable.new, 'ping', [])
+        ping
       }
       @inactivity_checker.on(:response_timeout) {
         EM::Hiredis.logger.warn("#{@name} - Closing connection because of inactivity timeout")
@@ -29,6 +29,10 @@ module EventMachine::Hiredis
       @response_queue.push(df)
       send_data(marshal(command, *args))
       return df
+    end
+
+    def ping
+      send_command(EM::DefaultDeferrable.new, 'ping', [])
     end
 
     def pending_responses
@@ -100,4 +104,5 @@ module EventMachine::Hiredis
       end
     end
   end
+
 end

--- a/spec/client_conn_spec.rb
+++ b/spec/client_conn_spec.rb
@@ -23,10 +23,12 @@ describe EM::Hiredis::Client do
       # Both connections expect to receive 'select' first
       # But pings 3 and 4 and issued between conn_a being disconnected
       # and conn_b completing its connection
+      conn_a._expect('ping')
       conn_a._expect('select 9')
       conn_a._expect('ping 1')
       conn_a._expect('ping 2')
 
+      conn_b._expect('ping')
       conn_b._expect('select 9')
       conn_b._expect('ping 3')
       conn_b._expect('ping 4')
@@ -83,14 +85,16 @@ describe EM::Hiredis::Client do
           got_errback = true
         }
 
-        good_connection._expect('select 9')
         good_connection._expect('ping')
+        good_connection._expect('select 9')
 
         # But after calling connect and completing the connection, we are functional again
         client.connect
         good_connection.connection_completed
 
+
         got_callback = false
+        good_connection._expect('ping')
         client.ping.callback {
           got_callback = true
         }
@@ -116,6 +120,7 @@ describe EM::Hiredis::Client do
           got_errback = true
         }
 
+        good_connection._expect('ping')
         good_connection._expect('select 9')
         good_connection._expect('ping')
 
@@ -149,6 +154,7 @@ describe EM::Hiredis::Client do
         # not connected yet
         conn_a.unbind
 
+        conn_b._expect('ping')
         conn_b._expect('select 9')
         conn_b.connection_completed
 
@@ -158,7 +164,7 @@ describe EM::Hiredis::Client do
 
     it 'should retry when partially set up' do
       mock_connections(2) { |client, (conn_a, conn_b)|
-        conn_a._expect_no_response('select 9')
+        conn_a._expect_no_response('ping')
 
         connected = false
         client.connect.callback {
@@ -169,6 +175,7 @@ describe EM::Hiredis::Client do
         # awaiting response to 'select'
         conn_a.unbind
 
+        conn_b._expect('ping')
         conn_b._expect('select 9')
         conn_b.connection_completed
 
@@ -178,6 +185,7 @@ describe EM::Hiredis::Client do
 
     it 'should reconnect once connected' do
       mock_connections(2) { |client, (conn_a, conn_b)|
+        conn_a._expect('ping')
         conn_a._expect('select 9')
 
         client.connect.errback {
@@ -193,6 +201,7 @@ describe EM::Hiredis::Client do
         # awaiting response to 'select'
         conn_a.unbind
 
+        conn_b._expect('ping')
         conn_b._expect('select 9')
         conn_b.connection_completed
 

--- a/spec/client_conn_spec.rb
+++ b/spec/client_conn_spec.rb
@@ -11,11 +11,14 @@ describe EM::Hiredis::Client do
   # Create expected_connections connections, inject them in order in to the
   # client as it creates new ones
   def mock_connections(expected_connections)
-    em = EM::Hiredis::MockConnectionEM.new(expected_connections, ClientTestConnection)
+    em {
+      em = EM::Hiredis::MockConnectionEM.new(expected_connections, ClientTestConnection)
 
-    yield EM::Hiredis::Client.new('redis://localhost:6379/9', nil, nil, em), em.connections
+      yield EM::Hiredis::Client.new('redis://localhost:6379/9', nil, nil, em), em.connections
 
-    em.connections.each { |c| c._expectations_met! }
+      em.connections.each { |c| c._expectations_met! }
+      done
+    }
   end
 
   it 'should queue commands issued while reconnecting' do

--- a/spec/client_server_spec.rb
+++ b/spec/client_server_spec.rb
@@ -2,6 +2,13 @@ require 'spec_helper'
 
 describe EM::Hiredis::Client do
 
+  around(:each) do |test|
+    EM.run do
+      test.run
+      EM.stop
+    end
+  end
+
   def recording_server(replies = {})
     em {
       yield NetworkedRedisMock::RedisMock.new(replies)
@@ -13,7 +20,7 @@ describe EM::Hiredis::Client do
 
     it 'should not connect on construction' do
       recording_server { |server|
-        client = EM::Hiredis::Client.new('redis://127.0.0.1:6381/9')
+        client = EM::Hiredis::Client.new('redis://localhost:6381/9')
         server.connection_count.should == 0
         done
       }
@@ -21,7 +28,7 @@ describe EM::Hiredis::Client do
 
     it 'should be connected when connect is called' do
       recording_server { |server|
-        client = EM::Hiredis::Client.new('redis://127.0.0.1:6381/9')
+        client = EM::Hiredis::Client.new('redis://localhost:6381/9')
         client.connect.callback {
           server.connection_count.should == 1
           done
@@ -31,9 +38,9 @@ describe EM::Hiredis::Client do
       }
     end
 
-    it 'should issue ping command before succeeding connection' do
+    it 'should issue ping and select command before succeeding connection' do
       recording_server { |server|
-        client = EM::Hiredis::Client.new('redis://127.0.0.1:6381/9')
+        client = EM::Hiredis::Client.new('redis://localhost:6381/9')
         client.connect.callback {
           server.connection_count.should == 1
           server.received[0].should == 'ping'
@@ -47,7 +54,7 @@ describe EM::Hiredis::Client do
 
     it 'should issue ping command before succeeding connection if no db' do
       recording_server { |server|
-        client = EM::Hiredis::Client.new('redis://127.0.0.1:6381')
+        client = EM::Hiredis::Client.new('redis://localhost:6381')
         client.connect.callback {
           server.connection_count.should == 1
           server.received[0].should == 'ping'
@@ -58,9 +65,9 @@ describe EM::Hiredis::Client do
       }
     end
 
-    it 'should issue pinf command before emitting :connected' do
+    it 'should issue ping command before emitting :connected' do
       recording_server { |server|
-        client = EM::Hiredis::Client.new('redis://127.0.0.1:6381/9')
+        client = EM::Hiredis::Client.new('redis://localhost:6381/9')
         client.on(:connected) {
           server.connection_count.should == 1
           server.received[0].should == 'ping'
@@ -76,7 +83,7 @@ describe EM::Hiredis::Client do
 
     it 'should emit :disconnected when the connection disconnects' do
       recording_server { |server|
-        client = EM::Hiredis::Client.new('redis://127.0.0.1:6381/9')
+        client = EM::Hiredis::Client.new('redis://localhost:6381/9')
         client.on(:disconnected) {
           done
         }
@@ -92,7 +99,7 @@ describe EM::Hiredis::Client do
 
     it 'should create a new connection if the existing one reports it has failed' do
       recording_server { |server|
-        client = EM::Hiredis::Client.new('redis://127.0.0.1:6381/9')
+        client = EM::Hiredis::Client.new('redis://localhost:6381/9')
         client.connect.callback {
           server.kill_connections
         }
@@ -105,7 +112,7 @@ describe EM::Hiredis::Client do
 
     it 'should emit both connected and reconnected' do
       recording_server { |server|
-        client = EM::Hiredis::Client.new('redis://127.0.0.1:6381/9')
+        client = EM::Hiredis::Client.new('redis://localhost:6381/9')
         client.connect.callback {
           callbacks = []
           client.on(:connected) {
@@ -131,7 +138,7 @@ describe EM::Hiredis::Client do
 
       it 'should make 4 attempts, emitting :reconnect_failed with a count' do
         em {
-          client = EM::Hiredis::Client.new('redis://127.0.0.1:9999') # assumes nothing listening on 9999
+          client = EM::Hiredis::Client.new('redis://localhost:9999') # assumes nothing listening on 9999
 
           expected = 1
           client.on(:reconnect_failed) { |count|
@@ -146,7 +153,7 @@ describe EM::Hiredis::Client do
 
       it 'after 4 unsuccessful attempts should emit :failed' do
         em {
-          client = EM::Hiredis::Client.new('redis://127.0.0.1:9999') # assumes nothing listening on 9999
+          client = EM::Hiredis::Client.new('redis://localhost:9999') # assumes nothing listening on 9999
 
           reconnect_count = 0
           client.on(:reconnect_failed) { |count|
@@ -181,7 +188,7 @@ describe EM::Hiredis::Client do
       it 'should recover from DNS resolution failure' do
         recording_server { |server|
           EM.stub(:connect).and_raise(EventMachine::ConnectionError.new)
-          client = EM::Hiredis::Client.new('redis://127.0.0.1:6381/9')
+          client = EM::Hiredis::Client.new('redis://localhost:6381/9')
 
           client.on(:reconnect_failed) {
             EM.rspec_reset
@@ -200,7 +207,7 @@ describe EM::Hiredis::Client do
 
       it 'should make 4 attempts, emitting :reconnect_failed with a count' do
         recording_server { |server|
-          client = EM::Hiredis::Client.new('redis://127.0.0.1:6381/9')
+          client = EM::Hiredis::Client.new('redis://localhost:6381/9')
           client.connect.callback {
             server.stop
             server.kill_connections
@@ -217,7 +224,7 @@ describe EM::Hiredis::Client do
 
       it 'after 4 unsuccessful attempts should emit :failed' do
         recording_server { |server|
-          client = EM::Hiredis::Client.new('redis://127.0.0.1:6381/9')
+          client = EM::Hiredis::Client.new('redis://localhost:6381/9')
           client.connect.callback {
             server.stop
             server.kill_connections
@@ -237,7 +244,7 @@ describe EM::Hiredis::Client do
 
     it 'should fail commands immediately when in a failed state' do
       recording_server { |server|
-        client = EM::Hiredis::Client.new('redis://127.0.0.1:6381/9')
+        client = EM::Hiredis::Client.new('redis://localhost:6381/9')
         client.connect.callback {
           client.on(:failed) {
             client.get('foo').errback { |e|
@@ -254,7 +261,7 @@ describe EM::Hiredis::Client do
 
     it 'should be possible to trigger reconnect on request' do
       recording_server { |server|
-        client = EM::Hiredis::Client.new('redis://127.0.0.1:6381/9')
+        client = EM::Hiredis::Client.new('redis://localhost:6381/9')
         client.connect.callback {
           client.on(:reconnected) {
             server.connection_count.should == 2
@@ -268,7 +275,7 @@ describe EM::Hiredis::Client do
 
     it 'should do something sensible???' do
       recording_server { |server|
-        client = EM::Hiredis::Client.new('redis://127.0.0.1:6381/9')
+        client = EM::Hiredis::Client.new('redis://localhost:6381/9')
         client.reconnect
         client.ping.callback {
           done
@@ -278,7 +285,7 @@ describe EM::Hiredis::Client do
 
     it 'should keep responses matched when connection is lost' do
       recording_server('get f' => '+hello') { |server|
-        client = EM::Hiredis::Client.new('redis://127.0.0.1:6381/9')
+        client = EM::Hiredis::Client.new('redis://localhost:6381/9')
         client.connect.callback {
           client.get('a')
           client.get('b').callback {
@@ -303,7 +310,7 @@ describe EM::Hiredis::Client do
 
     it 'should be able to send commands' do
       recording_server { |server|
-        client = EM::Hiredis::Client.new('redis://127.0.0.1:6381/9')
+        client = EM::Hiredis::Client.new('redis://localhost:6381/9')
         client.connect.callback {
           client.set('test', 'value').callback {
             done
@@ -314,7 +321,7 @@ describe EM::Hiredis::Client do
 
     it 'should queue commands called before connect is called' do
       recording_server { |server|
-        client = EM::Hiredis::Client.new('redis://127.0.0.1:6381/9')
+        client = EM::Hiredis::Client.new('redis://localhost:6381/9')
         client.set('test', 'value').callback {
           client.ping.callback {
             done
@@ -331,7 +338,7 @@ describe EM::Hiredis::Client do
 
     it 'should support alternative dbs' do
       recording_server { |server|
-        client = EM::Hiredis::Client.new('redis://127.0.0.1:6381/4')
+        client = EM::Hiredis::Client.new('redis://localhost:6381/4')
         client.connect.callback {
           server.received.should == ['ping','select 4']
           done
@@ -341,7 +348,7 @@ describe EM::Hiredis::Client do
 
     it 'should execute db selection first' do
       recording_server { |server|
-        client = EM::Hiredis::Client.new('redis://127.0.0.1:6381/9')
+        client = EM::Hiredis::Client.new('redis://localhost:6381/9')
         client.set('test', 'value').callback {
           client.ping.callback {
             server.received.should == [
@@ -359,7 +366,7 @@ describe EM::Hiredis::Client do
 
     it 'should class db selection failure as a connection failure' do
       recording_server('select 9' => '-ERR no such db') { |server|
-        client = EM::Hiredis::Client.new('redis://127.0.0.1:6381/9')
+        client = EM::Hiredis::Client.new('redis://localhost:6381/9')
         client.connect.errback { |e|
           done
         }
@@ -368,7 +375,7 @@ describe EM::Hiredis::Client do
 
     it 'should re-select db on reconnection' do
       recording_server { |server|
-        client = EM::Hiredis::Client.new('redis://127.0.0.1:6381/4')
+        client = EM::Hiredis::Client.new('redis://localhost:6381/4')
         client.connect.callback {
           client.ping.callback {
             client.on(:reconnected) {
@@ -394,7 +401,7 @@ describe EM::Hiredis::Client do
 
     it 'should remember a change in the selected db' do
       recording_server { |server|
-        client = EM::Hiredis::Client.new('redis://127.0.0.1:6381/9')
+        client = EM::Hiredis::Client.new('redis://localhost:6381/9')
         client.connect.callback {
           client.select(4).callback {
             client.on(:reconnected) {

--- a/spec/connection_manager_spec.rb
+++ b/spec/connection_manager_spec.rb
@@ -29,7 +29,7 @@ describe EM::Hiredis::ConnectionManager do
   context 'forcing reconnection' do
     it 'should be successful when disconnected from initial attempt failure' do
       em = EM::Hiredis::TimeMockEventMachine.new
-      conn_factory = double('connection factory')
+      conn_factory = mock('connection factory')
 
       manager = EM::Hiredis::ConnectionManager.new(conn_factory, em)
 
@@ -51,7 +51,7 @@ describe EM::Hiredis::ConnectionManager do
       manager.state.should == :connecting
 
       # Which will succeed
-      conn = double('connection')
+      conn = mock('connection')
       conn.expect_event_registration(:disconnected)
       second_conn_df.succeed(conn)
 
@@ -63,7 +63,7 @@ describe EM::Hiredis::ConnectionManager do
 
     it 'should be successful when disconnected from existing connection, triggered on disconnected' do
       em = EM::Hiredis::TimeMockEventMachine.new
-      conn_factory = double('connection factory')
+      conn_factory = mock('connection factory')
 
       manager = EM::Hiredis::ConnectionManager.new(conn_factory, em)
 
@@ -77,7 +77,7 @@ describe EM::Hiredis::ConnectionManager do
 
       manager.connect
 
-      initial_conn = double('initial connection')
+      initial_conn = mock('initial connection')
       disconnected_callback = initial_conn.expect_event_registration(:disconnected)
       initial_conn_df.succeed(initial_conn)
 
@@ -90,7 +90,7 @@ describe EM::Hiredis::ConnectionManager do
 
         manager.state.should == :connecting
 
-        second_conn = double('second connection')
+        second_conn = mock('second connection')
         second_conn.expect_event_registration(:disconnected)
         second_conn_df.succeed(second_conn)
       }
@@ -105,7 +105,7 @@ describe EM::Hiredis::ConnectionManager do
 
     it 'should be successful when disconnected from existing connection, triggered on reconnect_failed' do
       em = EM::Hiredis::TimeMockEventMachine.new
-      conn_factory = double('connection factory')
+      conn_factory = mock('connection factory')
 
       manager = EM::Hiredis::ConnectionManager.new(conn_factory, em)
 
@@ -121,7 +121,7 @@ describe EM::Hiredis::ConnectionManager do
 
       manager.connect
 
-      initial_conn = double('initial connection')
+      initial_conn = mock('initial connection')
       disconnected_callback = initial_conn.expect_event_registration(:disconnected)
       initial_conn_df.succeed(initial_conn)
 
@@ -134,7 +134,7 @@ describe EM::Hiredis::ConnectionManager do
 
         manager.state.should == :connecting
 
-        second_conn = double('second connection')
+        second_conn = mock('second connection')
         second_conn.expect_event_registration(:disconnected)
         second_conn_df.succeed(second_conn)
       }
@@ -151,7 +151,7 @@ describe EM::Hiredis::ConnectionManager do
     it 'should cancel the connection in progress when already connecting' do
       em = EM::Hiredis::TimeMockEventMachine.new
 
-      conn_factory = double('connection factory')
+      conn_factory = mock('connection factory')
       manager = EM::Hiredis::ConnectionManager.new(conn_factory, em)
 
       initial_conn_df = EM::DefaultDeferrable.new
@@ -169,7 +169,7 @@ describe EM::Hiredis::ConnectionManager do
 
       manager.state.should == :connecting
 
-      in_progress_connection = double('in progress connection')
+      in_progress_connection = mock('in progress connection')
       # the connection in progress when we called reconnect should be
       # immediately closed, because we might have reconfigured to connect to
       # something different
@@ -179,7 +179,7 @@ describe EM::Hiredis::ConnectionManager do
       # now we're trying to connect the replacement connection
       manager.state.should == :connecting
 
-      new_connection = double('replacement connection')
+      new_connection = mock('replacement connection')
       new_connection.expect_event_registration(:disconnected)
       second_conn_df.succeed(new_connection)
 
@@ -189,7 +189,7 @@ describe EM::Hiredis::ConnectionManager do
     it 'should reconnect again when already connecting and in-progress connection fails' do
       em = EM::Hiredis::TimeMockEventMachine.new
 
-      conn_factory = double('connection factory')
+      conn_factory = mock('connection factory')
       manager = EM::Hiredis::ConnectionManager.new(conn_factory, em)
 
       initial_conn_df = EM::DefaultDeferrable.new
@@ -211,7 +211,7 @@ describe EM::Hiredis::ConnectionManager do
       # now we're trying to connect the replacement connection
       manager.state.should == :connecting
 
-      new_connection = double('replacement connection')
+      new_connection = mock('replacement connection')
       new_connection.expect_event_registration(:disconnected)
       second_conn_df.succeed(new_connection)
 
@@ -221,7 +221,7 @@ describe EM::Hiredis::ConnectionManager do
     it 'should be successful when reconnecting' do
       em = EM::Hiredis::TimeMockEventMachine.new
 
-      conn_factory = double('connection factory')
+      conn_factory = mock('connection factory')
       manager = EM::Hiredis::ConnectionManager.new(conn_factory, em)
 
       initial_conn_df = EM::DefaultDeferrable.new
@@ -235,7 +235,7 @@ describe EM::Hiredis::ConnectionManager do
 
       manager.connect
 
-      initial_connection = double('initial connection')
+      initial_connection = mock('initial connection')
       disconnect_callback = initial_connection.expect_event_registration(:disconnected)
       initial_conn_df.succeed(initial_connection)
 
@@ -254,7 +254,7 @@ describe EM::Hiredis::ConnectionManager do
       # now we're trying to connect the replacement connection
       manager.state.should == :connecting
 
-      new_connection = double('replacement connection')
+      new_connection = mock('replacement connection')
       new_connection.expect_event_registration(:disconnected)
       manual_reconnect_df.succeed(new_connection)
 
@@ -263,7 +263,7 @@ describe EM::Hiredis::ConnectionManager do
 
     it 'should be successful when connected' do
       em = EM::Hiredis::TimeMockEventMachine.new
-      conn_factory = double('connection factory')
+      conn_factory = mock('connection factory')
 
       manager = EM::Hiredis::ConnectionManager.new(conn_factory, em)
 
@@ -276,7 +276,7 @@ describe EM::Hiredis::ConnectionManager do
 
       manager.connect
 
-      initial_conn = double('initial connection')
+      initial_conn = mock('initial connection')
       disconnected_callback = initial_conn.expect_event_registration(:disconnected)
       initial_conn_df.succeed(initial_conn)
 
@@ -293,7 +293,7 @@ describe EM::Hiredis::ConnectionManager do
       # ...we complete the reconnect
       manager.state.should == :connecting
 
-      second_conn = double('second connection')
+      second_conn = mock('second connection')
       second_conn.should_receive(:on).with(:disconnected)
       second_conn_df.succeed(second_conn)
 
@@ -305,7 +305,7 @@ describe EM::Hiredis::ConnectionManager do
 
     it 'should be successful when failed during initial connect' do
       em = EM::Hiredis::TimeMockEventMachine.new
-      conn_factory = double('connection factory')
+      conn_factory = mock('connection factory')
 
       manager = EM::Hiredis::ConnectionManager.new(conn_factory, em)
 
@@ -336,7 +336,7 @@ describe EM::Hiredis::ConnectionManager do
 
       manager.reconnect
 
-      conn = double('connection')
+      conn = mock('connection')
       conn.expect_event_registration(:disconnected)
       succeed_conn_df.succeed(conn)
 
@@ -349,7 +349,7 @@ describe EM::Hiredis::ConnectionManager do
     it 'should be successful when failed after initial success' do
       em = EM::Hiredis::TimeMockEventMachine.new
 
-      conn_factory = double('connection factory')
+      conn_factory = mock('connection factory')
       manager = EM::Hiredis::ConnectionManager.new(conn_factory, em)
 
       # Connect successfully, then five failed attempts takes us to failed,
@@ -369,7 +369,7 @@ describe EM::Hiredis::ConnectionManager do
 
       manager.connect
 
-      initial_conn = double('initial connection')
+      initial_conn = mock('initial connection')
       disconnected_cb = initial_conn.expect_event_registration(:disconnected)
       initial_conn_df.succeed(initial_conn)
 
@@ -389,7 +389,7 @@ describe EM::Hiredis::ConnectionManager do
 
       manager.reconnect
 
-      second_conn = double('second connection')
+      second_conn = mock('second connection')
       second_conn.expect_event_registration(:disconnected)
       second_conn_df.succeed(second_conn)
 

--- a/spec/connection_manager_spec.rb
+++ b/spec/connection_manager_spec.rb
@@ -29,7 +29,7 @@ describe EM::Hiredis::ConnectionManager do
   context 'forcing reconnection' do
     it 'should be successful when disconnected from initial attempt failure' do
       em = EM::Hiredis::TimeMockEventMachine.new
-      conn_factory = mock('connection factory')
+      conn_factory = double('connection factory')
 
       manager = EM::Hiredis::ConnectionManager.new(conn_factory, em)
 
@@ -51,7 +51,7 @@ describe EM::Hiredis::ConnectionManager do
       manager.state.should == :connecting
 
       # Which will succeed
-      conn = mock('connection')
+      conn = double('connection')
       conn.expect_event_registration(:disconnected)
       second_conn_df.succeed(conn)
 
@@ -63,7 +63,7 @@ describe EM::Hiredis::ConnectionManager do
 
     it 'should be successful when disconnected from existing connection, triggered on disconnected' do
       em = EM::Hiredis::TimeMockEventMachine.new
-      conn_factory = mock('connection factory')
+      conn_factory = double('connection factory')
 
       manager = EM::Hiredis::ConnectionManager.new(conn_factory, em)
 
@@ -77,7 +77,7 @@ describe EM::Hiredis::ConnectionManager do
 
       manager.connect
 
-      initial_conn = mock('initial connection')
+      initial_conn = double('initial connection')
       disconnected_callback = initial_conn.expect_event_registration(:disconnected)
       initial_conn_df.succeed(initial_conn)
 
@@ -90,12 +90,12 @@ describe EM::Hiredis::ConnectionManager do
 
         manager.state.should == :connecting
 
-        second_conn = mock('second connection')
+        second_conn = double('second connection')
         second_conn.expect_event_registration(:disconnected)
         second_conn_df.succeed(second_conn)
       }
 
-      disconnected_callback.call      
+      disconnected_callback.call
 
       manager.state.should == :connected
 
@@ -105,7 +105,7 @@ describe EM::Hiredis::ConnectionManager do
 
     it 'should be successful when disconnected from existing connection, triggered on reconnect_failed' do
       em = EM::Hiredis::TimeMockEventMachine.new
-      conn_factory = mock('connection factory')
+      conn_factory = double('connection factory')
 
       manager = EM::Hiredis::ConnectionManager.new(conn_factory, em)
 
@@ -121,7 +121,7 @@ describe EM::Hiredis::ConnectionManager do
 
       manager.connect
 
-      initial_conn = mock('initial connection')
+      initial_conn = double('initial connection')
       disconnected_callback = initial_conn.expect_event_registration(:disconnected)
       initial_conn_df.succeed(initial_conn)
 
@@ -134,13 +134,13 @@ describe EM::Hiredis::ConnectionManager do
 
         manager.state.should == :connecting
 
-        second_conn = mock('second connection')
+        second_conn = double('second connection')
         second_conn.expect_event_registration(:disconnected)
         second_conn_df.succeed(second_conn)
       }
 
       fail_conn_df.fail('Testing')
-      disconnected_callback.call      
+      disconnected_callback.call
 
       manager.state.should == :connected
 
@@ -151,7 +151,7 @@ describe EM::Hiredis::ConnectionManager do
     it 'should cancel the connection in progress when already connecting' do
       em = EM::Hiredis::TimeMockEventMachine.new
 
-      conn_factory = mock('connection factory')
+      conn_factory = double('connection factory')
       manager = EM::Hiredis::ConnectionManager.new(conn_factory, em)
 
       initial_conn_df = EM::DefaultDeferrable.new
@@ -169,7 +169,7 @@ describe EM::Hiredis::ConnectionManager do
 
       manager.state.should == :connecting
 
-      in_progress_connection = mock('in progress connection')
+      in_progress_connection = double('in progress connection')
       # the connection in progress when we called reconnect should be
       # immediately closed, because we might have reconfigured to connect to
       # something different
@@ -179,7 +179,7 @@ describe EM::Hiredis::ConnectionManager do
       # now we're trying to connect the replacement connection
       manager.state.should == :connecting
 
-      new_connection = mock('replacement connection')
+      new_connection = double('replacement connection')
       new_connection.expect_event_registration(:disconnected)
       second_conn_df.succeed(new_connection)
 
@@ -189,7 +189,7 @@ describe EM::Hiredis::ConnectionManager do
     it 'should reconnect again when already connecting and in-progress connection fails' do
       em = EM::Hiredis::TimeMockEventMachine.new
 
-      conn_factory = mock('connection factory')
+      conn_factory = double('connection factory')
       manager = EM::Hiredis::ConnectionManager.new(conn_factory, em)
 
       initial_conn_df = EM::DefaultDeferrable.new
@@ -211,7 +211,7 @@ describe EM::Hiredis::ConnectionManager do
       # now we're trying to connect the replacement connection
       manager.state.should == :connecting
 
-      new_connection = mock('replacement connection')
+      new_connection = double('replacement connection')
       new_connection.expect_event_registration(:disconnected)
       second_conn_df.succeed(new_connection)
 
@@ -221,7 +221,7 @@ describe EM::Hiredis::ConnectionManager do
     it 'should be successful when reconnecting' do
       em = EM::Hiredis::TimeMockEventMachine.new
 
-      conn_factory = mock('connection factory')
+      conn_factory = double('connection factory')
       manager = EM::Hiredis::ConnectionManager.new(conn_factory, em)
 
       initial_conn_df = EM::DefaultDeferrable.new
@@ -235,7 +235,7 @@ describe EM::Hiredis::ConnectionManager do
 
       manager.connect
 
-      initial_connection = mock('initial connection')
+      initial_connection = double('initial connection')
       disconnect_callback = initial_connection.expect_event_registration(:disconnected)
       initial_conn_df.succeed(initial_connection)
 
@@ -254,7 +254,7 @@ describe EM::Hiredis::ConnectionManager do
       # now we're trying to connect the replacement connection
       manager.state.should == :connecting
 
-      new_connection = mock('replacement connection')
+      new_connection = double('replacement connection')
       new_connection.expect_event_registration(:disconnected)
       manual_reconnect_df.succeed(new_connection)
 
@@ -263,7 +263,7 @@ describe EM::Hiredis::ConnectionManager do
 
     it 'should be successful when connected' do
       em = EM::Hiredis::TimeMockEventMachine.new
-      conn_factory = mock('connection factory')
+      conn_factory = double('connection factory')
 
       manager = EM::Hiredis::ConnectionManager.new(conn_factory, em)
 
@@ -276,7 +276,7 @@ describe EM::Hiredis::ConnectionManager do
 
       manager.connect
 
-      initial_conn = mock('initial connection')
+      initial_conn = double('initial connection')
       disconnected_callback = initial_conn.expect_event_registration(:disconnected)
       initial_conn_df.succeed(initial_conn)
 
@@ -293,7 +293,7 @@ describe EM::Hiredis::ConnectionManager do
       # ...we complete the reconnect
       manager.state.should == :connecting
 
-      second_conn = mock('second connection')
+      second_conn = double('second connection')
       second_conn.should_receive(:on).with(:disconnected)
       second_conn_df.succeed(second_conn)
 
@@ -305,7 +305,7 @@ describe EM::Hiredis::ConnectionManager do
 
     it 'should be successful when failed during initial connect' do
       em = EM::Hiredis::TimeMockEventMachine.new
-      conn_factory = mock('connection factory')
+      conn_factory = double('connection factory')
 
       manager = EM::Hiredis::ConnectionManager.new(conn_factory, em)
 
@@ -336,7 +336,7 @@ describe EM::Hiredis::ConnectionManager do
 
       manager.reconnect
 
-      conn = mock('connection')
+      conn = double('connection')
       conn.expect_event_registration(:disconnected)
       succeed_conn_df.succeed(conn)
 
@@ -349,7 +349,7 @@ describe EM::Hiredis::ConnectionManager do
     it 'should be successful when failed after initial success' do
       em = EM::Hiredis::TimeMockEventMachine.new
 
-      conn_factory = mock('connection factory')
+      conn_factory = double('connection factory')
       manager = EM::Hiredis::ConnectionManager.new(conn_factory, em)
 
       # Connect successfully, then five failed attempts takes us to failed,
@@ -369,7 +369,7 @@ describe EM::Hiredis::ConnectionManager do
 
       manager.connect
 
-      initial_conn = mock('initial connection')
+      initial_conn = double('initial connection')
       disconnected_cb = initial_conn.expect_event_registration(:disconnected)
       initial_conn_df.succeed(initial_conn)
 
@@ -389,12 +389,12 @@ describe EM::Hiredis::ConnectionManager do
 
       manager.reconnect
 
-      second_conn = mock('second connection')
+      second_conn = double('second connection')
       second_conn.expect_event_registration(:disconnected)
       second_conn_df.succeed(second_conn)
 
       manager.state.should == :connected
-    
+
       # Reconnect timers should have been cancelled
       em.remaining_timers.should == 0
     end

--- a/spec/live/pubsub_spec.rb
+++ b/spec/live/pubsub_spec.rb
@@ -51,7 +51,7 @@ describe EventMachine::Hiredis::PubsubClient, '(un)subscribe' do
         channel.should == channel
         message.should == 'foo'
 
-        callback_count.should == 2
+        callback_count.should == 3
         done
       }
 

--- a/spec/live/pubsub_spec.rb
+++ b/spec/live/pubsub_spec.rb
@@ -51,7 +51,7 @@ describe EventMachine::Hiredis::PubsubClient, '(un)subscribe' do
         channel.should == channel
         message.should == 'foo'
 
-        callback_count.should == 3
+        callback_count.should == 2
         done
       }
 

--- a/spec/live/redis_commands_spec.rb
+++ b/spec/live/redis_commands_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
-describe EventMachine::Hiredis, "commands" do
+describe EM::Hiredis, "commands" do
+
   it "pings" do
     connect do |redis|
       redis.ping.callback { |r| r.should == 'PONG'; done }

--- a/spec/pubsub_client_conn_spec.rb
+++ b/spec/pubsub_client_conn_spec.rb
@@ -21,6 +21,10 @@ describe EM::Hiredis::PubsubClient do
     it "should unsubscribe all callbacks for a channel on unsubscribe" do
       mock_connections(1) do |client, (connection)|
         client.connect
+
+        connection._expect_pubsub("subscribe __em-hiredis-ping")
+        connection._expect_pubsub("unsubscribe __em-hiredis-ping")
+
         connection.connection_completed
 
         connection._expect_pubsub('subscribe channel')
@@ -39,6 +43,10 @@ describe EM::Hiredis::PubsubClient do
     it "should not error when trying to unsubscribe a proc from a channel subscription that does not exist" do
       mock_connections(1) do |client, (connection)|
         client.connect
+
+        connection._expect_pubsub("subscribe __em-hiredis-ping")
+        connection._expect_pubsub("unsubscribe __em-hiredis-ping")
+
         connection.connection_completed
 
         lambda { client.unsubscribe_proc('channel', Proc.new { |m| fail }) }.should_not raise_error
@@ -48,6 +56,9 @@ describe EM::Hiredis::PubsubClient do
     it "should allow selective unsubscription" do
       mock_connections(1) do |client, (connection)|
         client.connect
+        connection._expect_pubsub("subscribe __em-hiredis-ping")
+        connection._expect_pubsub("unsubscribe __em-hiredis-ping")
+
         connection.connection_completed
 
         connection._expect_pubsub('subscribe channel')
@@ -70,6 +81,9 @@ describe EM::Hiredis::PubsubClient do
     it "should unsubscribe from redis when all subscriptions for a channel are unsubscribed" do
       mock_connections(1) do |client, (connection)|
         client.connect
+
+        connection._expect_pubsub("subscribe __em-hiredis-ping")
+        connection._expect_pubsub("unsubscribe __em-hiredis-ping")
         connection.connection_completed
 
         connection._expect_pubsub('subscribe channel')
@@ -94,6 +108,9 @@ describe EM::Hiredis::PubsubClient do
     it "should punsubscribe all callbacks for a pattern on punsubscribe" do
       mock_connections(1) do |client, (connection)|
         client.connect
+
+        connection._expect_pubsub("subscribe __em-hiredis-ping")
+        connection._expect_pubsub("unsubscribe __em-hiredis-ping")
         connection.connection_completed
 
         connection._expect_pubsub('psubscribe channel:*')
@@ -113,6 +130,9 @@ describe EM::Hiredis::PubsubClient do
     it "should allow selective punsubscription" do
       mock_connections(1) do |client, (connection)|
         client.connect
+
+        connection._expect_pubsub("subscribe __em-hiredis-ping")
+        connection._expect_pubsub("unsubscribe __em-hiredis-ping")
         connection.connection_completed
 
         connection._expect_pubsub('psubscribe channel:*')
@@ -135,6 +155,9 @@ describe EM::Hiredis::PubsubClient do
     it "should punsubscribe from redis when all psubscriptions for a pattern are punsubscribed" do
       mock_connections(1) do |client, (connection)|
         client.connect
+        connection._expect_pubsub("subscribe __em-hiredis-ping")
+        connection._expect_pubsub("unsubscribe __em-hiredis-ping")
+
         connection.connection_completed
 
         connection._expect_pubsub('psubscribe channel:*')
@@ -161,6 +184,10 @@ describe EM::Hiredis::PubsubClient do
     it 'should resubscribe all existing on reconnection' do
       mock_connections(2) do |client, (conn_a, conn_b)|
         client.connect
+
+        conn_a._expect_pubsub("subscribe __em-hiredis-ping")
+        conn_a._expect_pubsub("unsubscribe __em-hiredis-ping")
+
         conn_a.connection_completed
 
         channels = %w{foo bar baz}
@@ -198,6 +225,9 @@ describe EM::Hiredis::PubsubClient do
         # Trigger a reconnection
         conn_a.unbind
 
+        conn_b._expect_pubsub("subscribe __em-hiredis-ping")
+        conn_b._expect_pubsub("unsubscribe __em-hiredis-ping")
+
         # All subs previously made should be re-made
         conn_b._expect_pubsub("subscribe #{channels.join(' ')}")
         conn_b._expect_pubsub("psubscribe #{patterns.join(' ')}")
@@ -229,6 +259,8 @@ describe EM::Hiredis::PubsubClient do
         client.connect.callback {
           connected = true
         }
+        connection._expect('subscribe __em-hiredis-ping')
+        connection._expect('unsubscribe __em-hiredis-ping')
         connection.connection_completed
 
         connected.should == true
@@ -243,6 +275,9 @@ describe EM::Hiredis::PubsubClient do
         client.connect.callback {
           connected = true
         }
+        connection._expect_pubsub('subscribe __em-hiredis-ping')
+        connection._expect_pubsub('unsubscribe __em-hiredis-ping')
+
         connection.connection_completed
         connected.should == true
 
@@ -269,6 +304,8 @@ describe EM::Hiredis::PubsubClient do
           connected = true
         }
 
+        connection._expect_pubsub('subscribe __em-hiredis-ping')
+        connection._expect_pubsub('unsubscribe __em-hiredis-ping')
         connection._expect_pubsub('subscribe channel')
 
         message_received = nil
@@ -288,18 +325,25 @@ describe EM::Hiredis::PubsubClient do
 
     it 'should reconnect if auth command fails' do
       mock_connections(2, 'redis://:mypass@localhost:6379') do |client, (conn_a, conn_b)|
+
         conn_a._expect('auth mypass', RuntimeError.new('OOPS'))
         conn_b._expect('auth mypass')
+
 
         connected = false
         client.connect.callback {
           connected = true
         }
+
+        conn_b._expect('subscribe __em-hiredis-ping')
+        conn_b._expect('unsubscribe __em-hiredis-ping')
+
         conn_a.connection_completed
         connected.should == false
 
         conn_b.connection_completed
         connected.should == true
+
       end
     end
   end

--- a/spec/pubsub_connection_spec.rb
+++ b/spec/pubsub_connection_spec.rb
@@ -131,7 +131,7 @@ describe EM::Hiredis::PubsubConnection do
         con.connection_completed
 
         EM.add_timer(3) {
-          con.sent.should include("*2\r\n$9\r\nsubscribe\r\n$17\r\n__em-hiredis-ping\r\n")
+          con.sent.should include("*1\r\n$4\r\nping\r\n")
           done
         }
       }
@@ -148,7 +148,7 @@ describe EM::Hiredis::PubsubConnection do
         }
 
         EM.add_timer(3) {
-          con.sent.should_not include("*2\r\n$9\r\nsubscribe\r\n$17\r\n__em-hiredis-ping\r\n")
+          con.sent.should_not include("*2\r\n$9\r\nsubscribe\r\n$17\r\n*1\r\n$4\r\nping\r\n")
           done
         }
       }
@@ -165,11 +165,11 @@ describe EM::Hiredis::PubsubConnection do
         }
 
         EM.add_timer(3) {
-          con.sent.should_not include("*2\r\n$9\r\nsubscribe\r\n$17\r\n__em-hiredis-ping\r\n")
+          con.sent.should_not include("*1\r\n$4\r\nping\r\n")
         }
 
         EM.add_timer(4) {
-          con.sent.should include("*2\r\n$9\r\nsubscribe\r\n$17\r\n__em-hiredis-ping\r\n")
+          con.sent.should include("*1\r\n$4\r\nping\r\n")
           done
         }
       }
@@ -181,7 +181,7 @@ describe EM::Hiredis::PubsubConnection do
         con.connection_completed
 
         EM.add_timer(4) {
-          con.sent.should include("*2\r\n$9\r\nsubscribe\r\n$17\r\n__em-hiredis-ping\r\n")
+          con.sent.should include("*1\r\n$4\r\nping\r\n")
           con.closed.should == true
           done
         }
@@ -199,7 +199,7 @@ describe EM::Hiredis::PubsubConnection do
         }
 
         EM.add_timer(4) {
-          con.sent.should include("*2\r\n$9\r\nsubscribe\r\n$17\r\n__em-hiredis-ping\r\n")
+          con.sent.should include("*1\r\n$4\r\nping\r\n")
           con.closed.should_not == true
           done
         }


### PR DESCRIPTION
In the current implementation before emitting `:connected` the library does `select db`, which should be proceeded after the connection is established. Although currently selecting a database is the way how we establish if it's possible to connect to Redis. And if there are no db specified, this block will not be executed.
In this PR we execute `ping` before selecting the database, and if we don't receive pong as a reply means that the connection can't be established.

More information: https://pusher2.atlassian.net/browse/CHAN-487